### PR TITLE
open simpleBrowser to side

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -33,7 +33,7 @@ export const enum Commands {
   NewWindow = 'workbench.action.newWindow',
   ReloadWindow = 'workbench.action.reloadWindow',
   MarkdownShowPreview = 'markdown.showPreview',
-  ShowSimpleBrowser = 'simpleBrowser.api.show',
+  ShowSimpleBrowser = 'simpleBrowser.show',
   SetContext = 'setContext',
 
   // Evidence extension commands

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -33,7 +33,7 @@ export const enum Commands {
   NewWindow = 'workbench.action.newWindow',
   ReloadWindow = 'workbench.action.reloadWindow',
   MarkdownShowPreview = 'markdown.showPreview',
-  ShowSimpleBrowser = 'simpleBrowser.show',
+  ShowSimpleBrowser = 'simpleBrowser.api.show',
   SetContext = 'setContext',
 
   // Evidence extension commands

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -34,6 +34,7 @@ export const enum Commands {
   ReloadWindow = 'workbench.action.reloadWindow',
   MarkdownShowPreview = 'markdown.showPreview',
   ShowSimpleBrowser = 'simpleBrowser.show',
+  OpenSimpleBrowser = 'simpleBrowser.api.open',
   SetContext = 'setContext',
 
   // Evidence extension commands

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -109,8 +109,17 @@ export async function preview(uri?: Uri) {
  */
 async function openPageView(pageUri: Uri) {
   if (pageUri) {
-    // open requested page in the built-in simple browser webview to the side
-    commands.executeCommand(Commands.ShowSimpleBrowser, pageUri.toString(true), {
+    // open requested page in the built-in simple browser webview
+    // commands.executeCommand(Commands.ShowSimpleBrowser, 
+    //   pageUri.toString(true), 
+    //   {
+    //     options: {
+    //       viewColumn: ViewColumn.Two
+    //     }
+    //   }
+    // );
+
+    commands.executeCommand('simpleBrowser.api.open', pageUri.toString(true), {
       viewColumn: ViewColumn.Beside,
       preserveFocus: true
     });

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -110,8 +110,7 @@ export async function preview(uri?: Uri) {
 async function openPageView(pageUri: Uri) {
   if (pageUri) {
     // open requested page in the built-in simple browser webview to side 
-
-    commands.executeCommand('simpleBrowser.api.open', pageUri.toString(true), {
+    commands.executeCommand(Commands.OpenSimpleBrowser, pageUri.toString(true), {
       viewColumn: ViewColumn.Beside,
       preserveFocus: true
     });

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -109,15 +109,7 @@ export async function preview(uri?: Uri) {
  */
 async function openPageView(pageUri: Uri) {
   if (pageUri) {
-    // open requested page in the built-in simple browser webview
-    // commands.executeCommand(Commands.ShowSimpleBrowser, 
-    //   pageUri.toString(true), 
-    //   {
-    //     options: {
-    //       viewColumn: ViewColumn.Two
-    //     }
-    //   }
-    // );
+    // open requested page in the built-in simple browser webview to side 
 
     commands.executeCommand('simpleBrowser.api.open', pageUri.toString(true), {
       viewColumn: ViewColumn.Beside,

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,7 +1,8 @@
 import {
   commands,
   workspace,
-  Uri
+  Uri,
+  ViewColumn
 } from 'vscode';
 
 import { Commands } from './commands';
@@ -109,6 +110,18 @@ export async function preview(uri?: Uri) {
 async function openPageView(pageUri: Uri) {
   if (pageUri) {
     // open requested page in the built-in simple browser webview
-    commands.executeCommand(Commands.ShowSimpleBrowser, pageUri.toString(true)); // skip encoding
+    // commands.executeCommand(Commands.ShowSimpleBrowser, 
+    //   pageUri.toString(true), 
+    //   {
+    //     options: {
+    //       viewColumn: ViewColumn.Two
+    //     }
+    //   }
+    // );
+
+    commands.executeCommand('simpleBrowser.api.open', pageUri.toString(true), {
+      viewColumn: ViewColumn.Beside,
+      preserveFocus: true
+    });
   }
 }

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -109,17 +109,8 @@ export async function preview(uri?: Uri) {
  */
 async function openPageView(pageUri: Uri) {
   if (pageUri) {
-    // open requested page in the built-in simple browser webview
-    // commands.executeCommand(Commands.ShowSimpleBrowser, 
-    //   pageUri.toString(true), 
-    //   {
-    //     options: {
-    //       viewColumn: ViewColumn.Two
-    //     }
-    //   }
-    // );
-
-    commands.executeCommand('simpleBrowser.api.open', pageUri.toString(true), {
+    // open requested page in the built-in simple browser webview to the side
+    commands.executeCommand(Commands.ShowSimpleBrowser, pageUri.toString(true), {
       viewColumn: ViewColumn.Beside,
       preserveFocus: true
     });


### PR DESCRIPTION
@RandomFractals opened this in a branch so you can review and see what you think

This automatically opens the simple browser in the column beside the current one. It's the implementation [Gitpod use](https://github.com/gitpod-io/gitpod-code/blob/9dad90b81de9036d9592a3d17e812581939687a9/gitpod-web/src/portViewProvider.ts#L50)

![CleanShot 2023-06-05 at 20 39 24](https://github.com/evidence-dev/evidence-vscode/assets/58074498/1bdc1c12-a75d-4244-a0b0-e8dc5bc9bb42)

