### PR TITLE
Smooth Onboarding Flow

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -74,7 +74,7 @@ export async function buildProject() {
     stopServer();
     await timeout(1000);
   }
-  executeCommand('npm run build');
+  runCommandWithDepInstall('npm run build');
 }
 
 /**
@@ -87,7 +87,7 @@ export async function buildProjectStrict() {
     stopServer();
     await timeout(1000);
   }
-  executeCommand('npm run build:strict');
+  runCommandWithDepInstall('npm run build:strict');
 }
 
 /**
@@ -98,10 +98,10 @@ export async function buildProjectStrict() {
  *
  * @param command Terminal command to execute.
  */
-export async function executeCommand(command: string) {
-  if (!(await hasDependencies())) {
-    await installDependencies();
-  }
+export async function runCommandWithDepInstall(command: string) {
+  // if (!(await hasDependencies())) {
+  //   await installDependencies();
+  // }
   sendCommand(command);
 }
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -99,9 +99,9 @@ export async function buildProjectStrict() {
  * @param command Terminal command to execute.
  */
 export async function runCommandWithDepInstall(command: string) {
-  // if (!(await hasDependencies())) {
-  //   await installDependencies();
-  // }
+  if (!(await hasDependencies())) {
+    await installDependencies();
+  }
   sendCommand(command);
 }
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -99,10 +99,11 @@ export async function buildProjectStrict() {
  * @param command Terminal command to execute.
  */
 export async function runCommandWithDepInstall(command: string) {
+  let depCommand;
   if (!(await hasDependencies())) {
-    await installDependencies();
+    depCommand = `npm install && `;
   }
-  sendCommand(command);
+  sendCommand(depCommand + command);
 }
 
 /**

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -19,7 +19,7 @@ import { statusBar } from '../statusBar';
 import { cloneTemplateRepository } from './template';
 import { getExtensionFileUri } from '../extensionContext';
 import { folderExists, copyFolder } from '../utils/fsUtils';
-import { showInstallDependencies } from '../views/prompts';
+import { openNewProjectFolder, showInstallDependencies } from '../views/prompts';
 
 import {
   showSelectFolderDialog,
@@ -165,7 +165,8 @@ async function createProjectFolder(templateFolder: Uri, projectFolder: Uri) {
       // to enable all Evidence extensioin commands
       // and custom Evidence markdown Preview handling
       // for the Evidence app and markdown pages development
-      showOpenFolder(projectFolder);
+      openNewProjectFolder(projectFolder);
     }
   }
 }
+

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -1,7 +1,6 @@
 import { commands, env, workspace, Uri } from 'vscode';
 
 import { Commands } from './commands';
-import { executeCommand } from './build';
 import { Settings, getConfig } from '../config';
 import { getOutputChannel } from '../output';
 import { closeTerminal, sendCommand } from '../terminal';
@@ -69,14 +68,17 @@ export async function startServer(pageUri?: Uri) {
 
   // check supported node version prior to server start
   const nodeVersion = await getNodeVersion();
+  let dependencyCommand = "";
   if (isSupportedNodeVersion(nodeVersion, 16, 14)) {
 
     // check for /node_modules before starting dev server
     const nodeModules = await workspace.findFiles('**/node_modules/**/*.*');
     if (nodeModules.length === 0) {
       // prompt a user to install Evidence node.js dependencies
-      showInstallDependencies();
-      return;
+      // showInstallDependencies();
+      // return;
+
+      dependencyCommand = `npm install && `;
     }
 
     if (!_running) {
@@ -90,7 +92,7 @@ export async function startServer(pageUri?: Uri) {
       }
 
       // start dev server via terminal command
-      executeCommand(`npm exec evidence dev --${devServerHostParameter}${serverPortParameter}`);
+      sendCommand(`${dependencyCommand}npm exec evidence dev --${devServerHostParameter}${serverPortParameter}`);
     }
 
     // update server status and show running status bar icon

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -211,17 +211,19 @@ export async function cloneTemplateRepository(
 
           // check if open workspace folder is the same as the created project folder
           if (workspaceFolder && workspaceFolder.uri.fsPath !== projectFolderPath) {
+            commands.executeCommand(Commands.OpenFolder, Uri.file(projectFolderPath), true);
+
             // display Open Folder notification message
-            window.showInformationMessage(
-              `Evidence project created in: ${projectFolderPath}.`,
-              'Open Folder'
-            ).then((selection: string | undefined) => {
-              if (selection === 'Open Folder') {
-                // open created project folder in a new VS Code window
-                // if the user selected the Open Folder option
-                commands.executeCommand(Commands.OpenFolder, Uri.file(projectFolderPath), true);
-              }
-            });
+            // window.showInformationMessage(
+            //   `Evidence project created in: ${projectFolderPath}.`,
+            //   'Open Folder'
+            // ).then((selection: string | undefined) => {
+            //   if (selection === 'Open Folder') {
+            //     // open created project folder in a new VS Code window
+            //     // if the user selected the Open Folder option
+            //     commands.executeCommand(Commands.OpenFolder, Uri.file(projectFolderPath), true);
+            //   }
+            // });
           }
         }
       })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,10 +68,12 @@ export async function activate(context: ExtensionContext) {
     }
     else {
       // show install node modules status
-      statusBar.showInstall();
+      // statusBar.showInstall();
 
       // prompt a user to install Evidence node.js dependencies
-      showInstallDependencies();
+      // showInstallDependencies();
+
+      statusBar.showStart();
     }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,18 +52,6 @@ export async function activate(context: ExtensionContext) {
 
       if (autoStart) {
         startServer();
-
-        // show spinning progress bar for 25 seconds
-        window.withProgress({
-          location: ProgressLocation.Notification,
-          title: 'Starting Evidence dev server ...',
-          cancellable: false
-        }, async (progress) => {
-          for (let i = 0; i < 25; i++) {
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            progress.report({ increment: 4 });
-          }
-        });
       }
     }
     else {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -49,8 +49,8 @@ class StatusBar {
    * Sets app server status display to running.
    */
   showStart(): void {
-    this.statusBarItem.text = '$(debug-start) Evidence';
-    this.statusBarItem.tooltip = 'Start dev server';
+    this.statusBarItem.text = '$(debug-start) Run Evidence';
+    this.statusBarItem.tooltip = 'Start Evidence server';
     this.statusBarItem.command = Commands.StartServer;
     this.statusBarItem.show();
   }
@@ -59,8 +59,8 @@ class StatusBar {
    * Sets app server status display to running.
    */
   showRunning(): void {
-    this.statusBarItem.text = '$(sync~spin) Evidence';
-    this.statusBarItem.tooltip = 'Starting dev server ...';
+    this.statusBarItem.text = '$(sync~spin) Starting Evidence';
+    this.statusBarItem.tooltip = 'Starting Evidence server ...';
     this.statusBarItem.command = Commands.StopServer;
     this.statusBarItem.show();
   }
@@ -69,8 +69,8 @@ class StatusBar {
    * Sets app server status display to stop.
    */
   showStop(): void {
-    this.statusBarItem.text = '$(debug-disconnect) Evidence';
-    this.statusBarItem.tooltip = 'Stop dev server';
+    this.statusBarItem.text = '$(debug-disconnect) Evidence Running (Click to Stop)';
+    this.statusBarItem.tooltip = 'Stop Evidence server';
     this.statusBarItem.command = Commands.StopServer;
     this.statusBarItem.show();
   }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -40,7 +40,7 @@ async function getTerminal(context: ExtensionContext, workingDirectory?: string)
   if (_terminal === undefined) {
     _terminal = window.createTerminal(terminalName);
     _terminal.show(false);
-    _terminal.sendText('node -v');
+    // _terminal.sendText('node -v');
     _nodeVersion = await getNodeVersion();
     _outputChannel.appendLine(`Using node ${_nodeVersion}`);
 

--- a/src/views/prompts.ts
+++ b/src/views/prompts.ts
@@ -46,17 +46,22 @@ export async function showSelectFolderDialog(): Promise<Uri[] | undefined> {
  * @param projectFolder Project folder to open.
  */
 export async function showOpenFolder(projectFolder: Uri) {
+  // true = open in new window
+  // false = open in current window
+  // SET TO FALSE FOR TESTING ONLY - CHANGE TO TRUE BEFORE RELEASE
+  commands.executeCommand(Commands.OpenFolder, projectFolder, true);
+
   // display Open Folder notification message
-  window.showInformationMessage(
-    `Evidence project created in: ${projectFolder.fsPath}`,
-    'Open Folder'
-  ).then((selection: string | undefined) => {
-    if (selection === 'Open Folder') {
-      // open created project folder in a new VS Code window
-      // if the user selected the Open Folder option
-      commands.executeCommand(Commands.OpenFolder, projectFolder, true);
-    }
-  });
+  // window.showInformationMessage(
+  //   `Evidence project created in: ${projectFolder.fsPath}`,
+  //   'Open Folder'
+  // ).then((selection: string | undefined) => {
+  //   if (selection === 'Open Folder') {
+  //     // open created project folder in a new VS Code window
+  //     // if the user selected the Open Folder option
+  //     commands.executeCommand(Commands.OpenFolder, projectFolder, true);
+  //   }
+  // });
 }
 
 /**

--- a/src/views/prompts.ts
+++ b/src/views/prompts.ts
@@ -46,22 +46,30 @@ export async function showSelectFolderDialog(): Promise<Uri[] | undefined> {
  * @param projectFolder Project folder to open.
  */
 export async function showOpenFolder(projectFolder: Uri) {
+  // display Open Folder notification message
+  window.showInformationMessage(
+    `Evidence project created in: ${projectFolder.fsPath}`,
+    'Open Folder'
+  ).then((selection: string | undefined) => {
+    if (selection === 'Open Folder') {
+      // open created project folder in a new VS Code window
+      // if the user selected the Open Folder option
+      commands.executeCommand(Commands.OpenFolder, projectFolder, true);
+    }
+  });
+}
+
+/**
+ * Automatically opens new project folder
+ * in a new VS Code window
+ *
+ * @param projectFolder Project folder to open.
+ */
+export async function openNewProjectFolder(projectFolder: Uri) {
   // true = open in new window
   // false = open in current window
   // SET TO FALSE FOR TESTING ONLY - CHANGE TO TRUE BEFORE RELEASE
-  commands.executeCommand(Commands.OpenFolder, projectFolder, true);
-
-  // display Open Folder notification message
-  // window.showInformationMessage(
-  //   `Evidence project created in: ${projectFolder.fsPath}`,
-  //   'Open Folder'
-  // ).then((selection: string | undefined) => {
-  //   if (selection === 'Open Folder') {
-  //     // open created project folder in a new VS Code window
-  //     // if the user selected the Open Folder option
-  //     commands.executeCommand(Commands.OpenFolder, projectFolder, true);
-  //   }
-  // });
+  commands.executeCommand(Commands.OpenFolder, projectFolder, false);
 }
 
 /**

--- a/template/.npmrc
+++ b/template/.npmrc
@@ -1,0 +1,3 @@
+audit=false
+fund=false
+loglevel=error


### PR DESCRIPTION
This PR attempts to address several points related to making the onboarding process easier for new users:

- Closes #82 
   - When a new project is created, VS Code automatically opens the folder in a new window
   - **Currently set to open in the same VS Code window for testing purposes - should be changed before release** 
- Closes #83 
   - Adds a section to the Start Dev Server command to check for node_modules and if not found, prepend the run dev command with `npm install`
   - Removes the Install Dependencies command from usage in the pop-up prompt and the "play" button in the status bar 
- Closes #84
   - Removed - node version handled elsewhere  
- Closes #92
   - Adds `.npmrc` file to set options for the `npm install` command. Turns off noisy funding, audit, and deprecation messages, while retaining error messages 
- Closes #93 
   - Uses `Run Evidence`, `Starting Evidence`, and `Evidence Running (Click to Stop)` as labels for start, starting, and stop respectively
- Closes #99   