### PR TITLE
Hide create from template and show output commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,6 @@
         "category": "Evidence"
       },
       {
-        "command": "evidence.createProjectFromTemplate",
-        "title": "Create Project from Template",
-        "category": "Evidence"
-      },
-      {
         "command": "evidence.openSettings",
         "title": "Open Settings File",
         "category": "Evidence",
@@ -123,12 +118,6 @@
       {
         "command": "evidence.buildStrict",
         "title": "Build Strict",
-        "category": "Evidence",
-        "enablement": "evidence.hasProject"
-      },
-      {
-        "command": "evidence.showOutput",
-        "title": "Show Output",
         "category": "Evidence",
         "enablement": "evidence.hasProject"
       }


### PR DESCRIPTION
Removes `Create Project from Template` and `Show Output` commands from `package.json`. This means they are hidden from end users, but the underlying commands are still available should they need to be used in other places, or brought back in the future.

Pulling them out for now to limit the number of commands we're showing to new users of Evidence.

Closes #96 