### PR TITLE
Add preview type setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,23 @@
           "type": "string",
           "default": "/template",
           "description": "Evidence template project GitHub URL or local file:// path to the project template folder to use when creating new Evidence projects. Defaults to the built-in Evidence extension /template project."
+        },
+        "evidence.previewType": {
+          "type": "string",
+          "markdownDescription": "Preview location",
+          "enum": [
+            "internal",
+            "internal - side-by-side",
+            "external",
+            "none"
+          ],
+          "default": "internal",
+          "markdownEnumDescriptions": [
+            "VS Code default browser - full width",
+            "VS Code default browser - split-screen",
+            "Open in external web browser",
+            "No automatic preview shown"
+          ]
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
             "external",
             "none"
           ],
-          "default": "internal",
+          "default": "internal - side-by-side",
           "markdownEnumDescriptions": [
             "VS Code default browser - full width",
             "VS Code default browser - split-screen",

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -51,7 +51,8 @@ export const enum Commands {
   BuildProject = 'evidence.build',
   BuildProjectStrict = 'evidence.buildStrict',
   ShowOutput = 'evidence.showOutput',
-  OpenIndex = 'evidence.openIndex'
+  OpenIndex = 'evidence.openIndex',
+  OpenSimpleBrowser = 'simpleBrowser.api.open'
 }
 
 let _context: ExtensionContext;

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,12 +1,13 @@
 import {
   commands,
   workspace,
-  Uri
+  Uri,
+  ViewColumn
 } from 'vscode';
 
 import { Commands } from './commands';
 import { getExtensionContext } from '../extensionContext';
-import { Context, getWorkspaceFolder } from '../config';
+import { Settings, Context, getWorkspaceFolder, getConfig } from '../config';
 import { getOutputChannel } from '../output';
 
 import {
@@ -55,7 +56,7 @@ export async function preview(uri?: Uri) {
     await waitFor(homePage.toString(true), 1000, 30000); // encoding, ms interval, max total wait time ms
 
     // call the built-in simple browser once more
-    // to load the home page conent on server startup
+    // to load the home page content on server startup
     openPageView(homePage);
     return;
   }
@@ -107,8 +108,13 @@ export async function preview(uri?: Uri) {
  * @param pageUri Uri of the page to open.
  */
 async function openPageView(pageUri: Uri) {
+  const previewType: string = <string>getConfig(Settings.PreviewType);
+
   if (pageUri) {
-    // open requested page in the built-in simple browser webview
-    commands.executeCommand(Commands.ShowSimpleBrowser, pageUri.toString(true)); // skip encoding
+    // open requested page in the built-in simple browser webview to side 
+    commands.executeCommand(Commands.OpenSimpleBrowser, pageUri.toString(true), {
+      viewColumn: previewType === 'internal' ? ViewColumn.Active : ViewColumn.Beside,
+      preserveFocus: true
+    });  
   }
 }

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -66,6 +66,8 @@ export async function startServer(pageUri?: Uri) {
     pageUri = await getAppPageUri('/');
   }
 
+  const previewType: string = <string>getConfig(Settings.PreviewType);
+
   // check supported node version prior to server start
   const nodeVersion = await getNodeVersion();
   let dependencyCommand = "";
@@ -91,8 +93,13 @@ export async function startServer(pageUri?: Uri) {
         devServerHostParameter = ' --host 0.0.0.0';
       }
 
+      let previewParameter: string = '';
+      if(previewType === 'external'){
+        previewParameter = ' --open /';
+      }
+
       // start dev server via terminal command
-      sendCommand(`${dependencyCommand}npm exec evidence dev --${devServerHostParameter}${serverPortParameter}`);
+      sendCommand(`${dependencyCommand}npm exec evidence dev --${devServerHostParameter}${serverPortParameter}${previewParameter}`);
     }
 
     // update server status and show running status bar icon
@@ -108,8 +115,12 @@ export async function startServer(pageUri?: Uri) {
     // set focus back to the active vscode editor group
     commands.executeCommand(Commands.FocusActiveEditorGroup);
 
-    // open app preview
-    preview(pageUri);
+    // open app preview if previewType is set to internal (simple browser)
+    if(previewType === 'internal' || previewType === 'internal - side-by-side'){
+      preview(pageUri);
+    }
+
+    // change button to stop server
     statusBar.showStop();
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,8 @@ import { getExtensionContext } from './extensionContext';
 export const enum Settings {
   DefaultPort = 'defaultPort',
   AutoStart = 'autoStart',
-  TemplateProjectUrl = 'templateProjectUrl'
+  TemplateProjectUrl = 'templateProjectUrl',
+  PreviewType = 'previewType'
 }
 
 /**


### PR DESCRIPTION
- Closes #94 
- Closes #86

This works well to decide how to show the preview of the app. Options are:
- Internal (Simple browser full width)
- Internal - side-by-side (simple browser in split-screen editor)
- External (opens browser)
- None (no preview generated when dev server is started)

Remaining issue:
- Dynamic port numbers - the external preview option is less flexible than our current local development experience, where we can open in a browser any ports that are used from the sveltekit app (noted in #31)