### PR TITLE
Keyboard Shortcuts and Command Names

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,13 +86,13 @@
       },
       {
         "command": "evidence.startServer",
-        "title": "Start Dev Server",
+        "title": "Start Evidence Server",
         "category": "Evidence",
         "enablement": "evidence.hasProject"
       },
       {
         "command": "evidence.stopServer",
-        "title": "Stop Dev Server",
+        "title": "Stop Evidence Server",
         "category": "Evidence",
         "enablement": "evidence.hasProject"
       },
@@ -193,13 +193,13 @@
       "properties": {
         "evidence.autoStart": {
           "type": "boolean",
-          "default": true,
-          "description": "Autostart Evidence dev server when VS Code opens Evidence project workspace."
+          "default": false,
+          "description": "Autostart Evidence server when VS Code opens Evidence project workspace."
         },
         "evidence.defaultPort": {
           "type": "number",
           "default": 3000,
-          "description": "Default Evidence dev server port."
+          "description": "Default Evidence server port."
         },
         "evidence.templateProjectUrl": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,32 @@
         "enablement": "evidence.hasProject"
       }
     ],
+    "keybindings": [
+      {
+        "command": "evidence.startServer",
+        "key": "ctrl+R",
+        "mac": "cmd+R",
+        "enablement": "evidence.hasProject"
+      },
+      {
+        "command": "evidence.stopServer",
+        "key": "ctrl+shift+R",
+        "mac": "cmd+shift+R",
+        "enablement": "evidence.hasProject"
+      },
+      {
+        "command": "evidence.build",
+        "key": "ctrl+shift+B",
+        "mac": "cmd+shift+B",
+        "enablement": "evidence.hasProject"
+      },
+      {
+        "command": "evidence.buildStrict",
+        "key": "ctrl+shift+alt+B",
+        "mac": "cmd+shift+alt+B",
+        "enablement": "evidence.hasProject"
+      }
+    ],
     "menus": {
       "explorer/context": [
         {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -29,8 +29,8 @@ class StatusBar {
    * Sets app server status display to install dependencies.
    */
   showInstall(): void {
-    this.statusBarItem.text = '$(debug-start) Evidence';
-    this.statusBarItem.tooltip = 'Install dependencies';
+    this.statusBarItem.text = '$(cloud-download) Install Evidence';
+    this.statusBarItem.tooltip = 'Install required Evidence dependencies';
     this.statusBarItem.command = Commands.InstallDependencies;
     this.statusBarItem.show();
   }
@@ -39,8 +39,8 @@ class StatusBar {
    * Sets installing dependencies app server status.
    */
   showInstalling(): void {
-    this.statusBarItem.text = '$(sync~spin) Evidence';
-    this.statusBarItem.tooltip = 'Installing dependencies ...';
+    this.statusBarItem.text = '$(sync~spin) Installing Evidence';
+    this.statusBarItem.tooltip = 'Installing Evidence dependencies ...';
     this.statusBarItem.command = Commands.InstallDependencies;
     this.statusBarItem.show();
   }
@@ -49,7 +49,7 @@ class StatusBar {
    * Sets app server status display to running.
    */
   showStart(): void {
-    this.statusBarItem.text = '$(debug-start) Run Evidence';
+    this.statusBarItem.text = '$(debug-start) Start Evidence';
     this.statusBarItem.tooltip = 'Start Evidence server';
     this.statusBarItem.command = Commands.StartServer;
     this.statusBarItem.show();
@@ -69,7 +69,7 @@ class StatusBar {
    * Sets app server status display to stop.
    */
   showStop(): void {
-    this.statusBarItem.text = '$(debug-disconnect) Evidence Running (Click to Stop)';
+    this.statusBarItem.text = '$(debug-disconnect) Stop Evidence';
     this.statusBarItem.tooltip = 'Stop Evidence server';
     this.statusBarItem.command = Commands.StopServer;
     this.statusBarItem.show();


### PR DESCRIPTION
## Shortcuts
- Ctrl + R: Start Evidence server
- Ctrl + Shift + R: Stop Evidence server
- Ctrl + Shift + B: Build
- Ctrl + Shift + Alt + B: Strict Build
(plus macOS equivalents)

## StatusBar Names
- Install Evidence (though this may be redundant)
- Start Evidence
- Starting Evidence...
- Stop Evidence

## Autostart
- Default to false