### PR TITLE
Add node version checks and errors

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -3,13 +3,16 @@ import {
   FileStat,
   FileType,
   Uri,
-  WorkspaceFolder
+  WorkspaceFolder,
+  window,
+  env
 } from 'vscode';
 
 import { sendCommand } from '../terminal';
 import { timeout } from '../utils/timer';
 import { isServerRunning, stopServer } from './server';
 import { statusBar } from '../statusBar';
+import { getNodeVersion, isSupportedNodeVersion } from '../node';
 import { getWorkspaceFolder, updateProjectContext } from '../config';
 
 /**
@@ -19,6 +22,9 @@ import { getWorkspaceFolder, updateProjectContext } from '../config';
  * @see https://docs.evidence.dev/getting-started/install-evidence
  */
 const nodeModules = `node_modules`;
+
+const downloadNodeJs = 'Download NodeJS';
+const downloadNodeJsUrl = 'https://nodejs.org/en/download';
 
 /**
  * Evidence node modules to update to the latest version.
@@ -35,20 +41,37 @@ const evidencePackages: string[] = [
  * @see https://docs.evidence.dev/getting-started/install-evidence
  */
 export async function installDependencies() {
-  if (isServerRunning()) {
-    stopServer();
-    await timeout(1000);
-  }
-  else {
-    // update open workspace context
-    updateProjectContext();
-  }
 
-  sendCommand('npm install');
-  await timeout(1000);
-  statusBar.showInstalling();
-  await timeout(25000);
-  statusBar.showStart();
+  // check supported node version prior to server start
+  const nodeVersion = await getNodeVersion();
+  if (!isSupportedNodeVersion(nodeVersion)) {
+     // prompt to download and install the required NodeJS version
+     const downloadNodeNotification = window.showErrorMessage(
+       'Evidence requires NodeJS v16.14 or greater.', {
+         title: downloadNodeJs
+       });
+
+     downloadNodeNotification.then(async (result) => {
+       if (result?.title === downloadNodeJs) {
+         env.openExternal(Uri.parse(downloadNodeJsUrl));
+       }
+     });
+ } else {   
+    if (isServerRunning()) {
+      stopServer();
+      await timeout(1000);
+    }
+    else {
+      // update open workspace context
+      updateProjectContext();
+    }
+
+    sendCommand('npm install');
+    await timeout(1000);
+    statusBar.showInstalling();
+    await timeout(25000);
+    statusBar.showStart();
+  }
 }
 
 /**
@@ -99,11 +122,28 @@ export async function buildProjectStrict() {
  * @param command Terminal command to execute.
  */
 export async function runCommandWithDepInstall(command: string) {
-  let depCommand;
-  if (!(await hasDependencies())) {
-    depCommand = `npm install && `;
+
+   // check supported node version prior to server start
+   const nodeVersion = await getNodeVersion();
+   if (!isSupportedNodeVersion(nodeVersion)) {
+      // prompt to download and install the required NodeJS version
+      const downloadNodeNotification = window.showErrorMessage(
+        'Evidence requires NodeJS v16.14 or greater.', {
+          title: downloadNodeJs
+        });
+
+      downloadNodeNotification.then(async (result) => {
+        if (result?.title === downloadNodeJs) {
+          env.openExternal(Uri.parse(downloadNodeJsUrl));
+        }
+      });
+  } else {   
+    let depCommand;
+    if (!(await hasDependencies())) {
+      depCommand = `npm install && `;
+    }
+    sendCommand(depCommand + command);
   }
-  sendCommand(depCommand + command);
 }
 
 /**

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,4 +1,5 @@
 import { exec } from 'child_process';
+import { window } from 'vscode';
 
 /**
  * Gets NodeJS version.
@@ -14,14 +15,16 @@ export async function getNodeVersion() {
  * meets the major and minor version requirements.
  *
  * @param nodeVersion NodeJS version string to check.
- * @param majorVersion Major version number.
- * @param minorVersion Minor version number.
  *
- * @returns Trus if NodeJS version is equal or greater
+ * @returns True if NodeJS version is equal or greater
  *  than the major and minor version numbers, and false otherwise.
  */
-export function isSupportedNodeVersion(nodeVersion: string,
-  majorVersion: number, minorVersion: number): boolean {
+export function isSupportedNodeVersion(nodeVersion: string): boolean {
+
+  // Minimum version of NodeJS required for Evidence:
+  const majorVersion = 26;
+  const minorVersion = 14;
+
   // check node version
   if (nodeVersion && nodeVersion.startsWith('v')) {
     const nodeVersionNumbers = nodeVersion.replace('v', '').split('.');
@@ -67,4 +70,14 @@ export function executeCommand(command: string): Promise<string> {
       }
     });
   });
+}
+
+
+export async function nodeCheck() {
+  const nodeVersion = await getNodeVersion();
+  const isSupported = isSupportedNodeVersion(nodeVersion);
+
+  if(!isSupported){
+    window.showErrorMessage(`Not right NodeJS!`);
+  }
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -82,7 +82,7 @@ export async function sendCommand(command: string,
 
   // check node version
   // @see https://docs.evidence.dev/getting-started/install-evidence#system-requirements
-  if (isSupportedNodeVersion(_nodeVersion!, 16, 14)) {
+  if (isSupportedNodeVersion(_nodeVersion!)) {
     // execute terminal command
     terminal.sendText(command, true); // add new line
 
@@ -96,7 +96,7 @@ export async function sendCommand(command: string,
   else {
     // prompt to download and install the required NodeJS version
     const downloadNodeNotification = window.showInformationMessage(
-      'Evidence application requires NodeJS v16.14 or greater.', {
+      'Evidence requires NodeJS v16.14 or greater.', {
         title: downloadNodeJs
       });
 


### PR DESCRIPTION
- Closes #81

Adds a node check to 3 places:
- Start server
- Run build
- Install dependencies

In all cases, if node is not found or version not supported, an error message will display prompting the user to install NodeJS and providing a link to the download page.