### PR TITLE
Fix server stop conflict

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -99,7 +99,7 @@ export async function buildProjectStrict() {
  * @param command Terminal command to execute.
  */
 export async function runCommandWithDepInstall(command: string) {
-  let depCommand;
+  let depCommand = "";
   if (!(await hasDependencies())) {
     depCommand = `npm install && `;
   }

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -105,23 +105,26 @@ export async function startServer(pageUri?: Uri) {
     // update server status and show running status bar icon
     statusBar.showRunning();
 
+    _running = true;
+
     // wait for the dev server to start
     await timeout(1000);
-    _running = true;
 
     // wait for the server to process pages
     await timeout(5000);
 
-    // set focus back to the active vscode editor group
-    commands.executeCommand(Commands.FocusActiveEditorGroup);
+    if(_running === true){
+      // set focus back to the active vscode editor group
+      commands.executeCommand(Commands.FocusActiveEditorGroup);
 
-    // open app preview if previewType is set to internal (simple browser)
-    if(previewType === 'internal' || previewType === 'internal - side-by-side'){
-      preview(pageUri);
+      // open app preview if previewType is set to internal (simple browser)
+      if(previewType === 'internal' || previewType === 'internal - side-by-side'){
+        preview(pageUri);
+      }
+
+      // change button to stop server
+      statusBar.showStop();
     }
-
-    // change button to stop server
-    statusBar.showStop();
   }
 }
 
@@ -148,7 +151,7 @@ export function getActivePort() {
  * resets active port number,
  * and closes Evidence app terminal.
  */
-export function stopServer() {
+export async function stopServer() {
   if (_running) {
     sendCommand('q', '', false);
   }


### PR DESCRIPTION
- Closes #103 

Makes `stopServer` function asynchronous and changes `_running` flag to false, which causes `startServer` to complete it's run early.
