### PR TITLE
Clean up dependency checks and add installing status

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,31 +44,17 @@ export async function activate(context: ExtensionContext) {
     // set Evidence project context
     updateProjectContext();
 
-    // check for node modules and auto start dev server
-    const nodeModules = await workspace.findFiles('**/node_modules/**/*.*');
+    // get autoStart setting:
     const autoStart: boolean = <boolean>getConfig(Settings.AutoStart);
-    if (nodeModules.length > 0) {
-      // show start dev server status
-      statusBar.showStart();
 
-      // open index.md if no other files are open
-      openIndex();
+    // show start dev server status
+    statusBar.showStart();
 
-      if (autoStart) {
-        startServer();
-      }
-    }
-    else {
-      // show install node modules status
-      // statusBar.showInstall();
+    // open index.md if no other files are open
+    openIndex();
 
-      // prompt a user to install Evidence node.js dependencies
-      // showInstallDependencies();
-
-      statusBar.showStart();
-
-      // open index.md if no other files are open
-      openIndex();
+    if (autoStart) {
+      startServer();
     }
   }
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -77,13 +77,3 @@ export function executeCommand(command: string): Promise<string> {
     });
   });
 }
-
-
-export async function nodeCheck() {
-  const nodeVersion = await getNodeVersion();
-  const isSupported = isSupportedNodeVersion(nodeVersion);
-
-  if(!isSupported){
-    window.showErrorMessage(`Not right NodeJS!`);
-  }
-}

--- a/src/node.ts
+++ b/src/node.ts
@@ -7,7 +7,13 @@ import { window } from 'vscode';
  * @returns The NodeJS version.
  */
 export async function getNodeVersion() {
-  return await executeCommand('node --version');
+  let nodeVersion;
+  try {
+    nodeVersion = await executeCommand('node --version');
+  } catch(e) {
+    nodeVersion = "none";
+  }
+  return nodeVersion;
 }
 
 /**


### PR DESCRIPTION
Replaces the `node_modules` folder checks with the `hasDependencies` function. It was causing an issue if you delete your `node_modules` folder - the folder check was picking up the node_modules from the hidden `.evidence` template and assuming the dependencies were installed. The `hasDependencies` function doesn't have that issue.

This also adds an installing status to the status bar if dependencies are being installed. It's been set with an arbitrary time of 2500 - this may not be stable enough to keep in.