### PR TITLE
Fix pages directory path check for windows

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -73,7 +73,7 @@ export async function preview(uri?: Uri) {
     }
   }
 
-  if (!isEvidenceProject || !isServerRunning() || !uri?.path.includes('/pages/')) {
+  if (!isEvidenceProject || !isServerRunning() || /\/pages\/|\\pages\\/.test(uri?.path ?? '')) {
     // show standard markdown document preview
     commands.executeCommand(Commands.MarkdownShowPreview, uri);
     return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ function isPagesDirectory(){
   const openEditor = window.activeTextEditor;
   let pageContext = false;
   // Set context for pages directory (only use Evidence markdown features within those files):
-  if(openEditor && openEditor.document.uri.fsPath.includes("/pages/")){
+  if(openEditor && /\/pages\/|\\pages\\/.test(openEditor.document.uri.fsPath)){
    commands.executeCommand(Commands.SetContext, Context.isPagesDirectory, true);  
    pageContext = true;
   } else {


### PR DESCRIPTION
The pages directory path check on Windows was accidentally failing because the slashes were in the wrong direction. this was breaking the slash commands