### PR TITLE
working command for directory to run server in

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -76,6 +76,10 @@ export async function startServer(pageUri?: Uri) {
     promptToInstallNodeJsAndRestart();
   } else {
 
+    // change to Evidence project root directory if needed
+    const cdToEvidence = `cd reports; `;
+    const cdBackToRoot = `; cd ..`;
+    
     // check for /node_modules before starting dev server
     let dependencyCommand = "";
     let depTimeout = 0;
@@ -105,7 +109,7 @@ export async function startServer(pageUri?: Uri) {
       }
 
       // start dev server via terminal command
-      sendCommand(`${dependencyCommand}npm exec evidence dev --${devServerHostParameter}${serverPortParameter}${previewParameter}`);
+      sendCommand(`${cdToEvidence}${dependencyCommand}npm exec evidence dev --${devServerHostParameter}${serverPortParameter}${previewParameter}${cdBackToRoot}`);
     }
 
     statusBar.showInstalling();

--- a/src/utils/jsonUtils.ts
+++ b/src/utils/jsonUtils.ts
@@ -13,10 +13,11 @@ import { getWorkspaceFolder } from '../config';
  * @returns package.json file content, or udefined if package.json file doesn't exist.
  */
 export async function loadPackageJson(): Promise<any | undefined> {
-  const packageJsonFiles = await workspace.findFiles('package.json');
+  // find all package.json files in the workspace outside of node_modules
+  const packageJsonFiles = await workspace.findFiles('**/package.json', '**/node_modules/**/*');
   if (workspace.workspaceFolders && packageJsonFiles.length > 0) {
-    // get package.json from the top workspace folder for now
-    const packageJsonUri: Uri = Uri.joinPath(getWorkspaceFolder()!.uri, 'package.json');
+    // get package.json from the first workspace folder for now
+    const packageJsonUri: Uri = packageJsonFiles[0];
     const packageJsonContent = await workspace.fs.readFile(packageJsonUri);
     const textDecoder = new TextDecoder('utf-8');
     const packageJson = JSON.parse(textDecoder.decode(packageJsonContent));


### PR DESCRIPTION
DO NOT MERGE

This shows how you can use `cd`  to run evidence in a subdirectory.

This gets around the fact that you cannot use `npm exec --prefix reports evidence dev`