### PR TITLE
add monorepo support for commands

### DIFF
--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -23,6 +23,7 @@ import { statusBar } from '../statusBar';
 import { cloneTemplateRepository } from './template';
 import { getExtensionFileUri } from '../extensionContext';
 import { folderExists, copyFolder } from '../utils/fsUtils';
+import { getPackageJsonFolder } from '../utils/jsonUtils';
 import { openNewProjectFolder } from '../views/prompts';
 import { telemetryService } from '../extension';
 
@@ -195,7 +196,10 @@ async function createProjectFolder(templateFolder: Uri, projectFolder: Uri) {
 export async function openIndex() {
   let openMarkdownFiles = workspace.textDocuments.filter(doc => doc.fileName.endsWith('.md'));
 
-  if (openMarkdownFiles.length === 0) {
+  // check if evidence is in a subdirectory - don't open index/walkthrough if monorepo
+  const packageJsonFolder = await getPackageJsonFolder();
+
+  if (packageJsonFolder === '' && openMarkdownFiles.length === 0) {
     const folderPath = getWorkspaceFolder();
     const filePath = folderPath?.uri.toString() + '/pages/index.md';
     const fileUri = Uri.parse(filePath);

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -1,9 +1,9 @@
 import { sendCommand } from '../terminal';
 import { timeout } from '../utils/timer';
 import { isServerRunning, startServer, stopServer } from './server';
-import { isUSQL, getTypesFromConnections } from '../utils/jsonUtils';
+import { isUSQL, getTypesFromConnections, getPackageJsonFolder } from '../utils/jsonUtils';
 import { telemetryService } from '../extension';
-import { window } from 'vscode';
+import { window, workspace } from 'vscode';
 
 export async function runSources() {
   if(await isUSQL()){
@@ -13,7 +13,14 @@ export async function runSources() {
       stopServer();
       await timeout(1000);
     }
-    sendCommand(`npm run sources`);
+
+    // check if we need to run command in a different directory than root of the project:
+    const workspaceFolderPath = workspace.workspaceFolders ? workspace.workspaceFolders[0].uri.fsPath : '';
+    const packageJsonFolder = await getPackageJsonFolder();
+    const cdCommand = packageJsonFolder ? `cd ${packageJsonFolder} && ` : '';
+    const cdBackCommand = packageJsonFolder ? `; cd ${workspaceFolderPath}` : '';
+
+    sendCommand(`${cdCommand}npm run sources${cdBackCommand}`);
 
     const sourceNames = await getTypesFromConnections();
   
@@ -23,7 +30,7 @@ export async function runSources() {
       startServer();
     }
   } else {
-    window.showErrorMessage('Run Sources is only available in Evidence versions >= 24');
+    window.showErrorMessage('Run Sources is only available in Evidence versions >= 24 (Universal SQL)');
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import { Commands } from './commands/commands';
 import { MarkdownSymbolProvider } from './providers/markdownSymbolProvider';
 import { setExtensionContext } from './extensionContext';
 import { registerCommands } from './commands/commands';
-import { loadPackageJson, hasDependency, dependencyVersion, getManifestUri, getManifest, isUSQL, hasManifest } from './utils/jsonUtils';
+import { loadPackageJson, getPackageJsonFolder, hasDependency, dependencyVersion, getManifestUri, getManifest, isUSQL, hasManifest } from './utils/jsonUtils';
 import { Settings, getConfig, updateProjectContext } from './config';
 import { startServer } from './commands/server';
 import { openIndex, openWalkthrough } from './commands/project';


### PR DESCRIPTION
- Checks for package json in all folders and picks the first one found
- Prefixes all commands with `cd` to the directory containing the package.json
- Suffixes all commands with `cd` back to the root directory of the vscode workspace
- Fixes activation to work in monorepo setup (was previous only allowing package.json at root)